### PR TITLE
Wrong labeling of link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ Praise is an open source system developed by [Commons Stack](https://commonsstac
 
 - [Discord](http://discord.link/commonsstack)
 - [Telegram](https://t.me/joinchat/HGrjjRS2PoowbH1ODuefuA)
-- [Discord](https://twitter.com/commonsstack)
+- [Twitter](https://twitter.com/commonsstack)
 
 ## Commons Stack Services
 


### PR DESCRIPTION
reach out section had Discord linked twice. The second Discord link label is actually pointing to Twitter so I suggest changing the title of the link also to "Twitter"